### PR TITLE
option to show small versions of the images in the gallery

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,24 +1,28 @@
-baseurl                 = "https://example.org/"               # Your domain name. Must end with "/"
-languageCode            = "en-us"
-title                   = "Call me Sam"
-theme                   = "sam"
-pygmentsStyle           = "monokai"                     # https://help.farbox.com/pygments.html
-pygmentsCodefences      = true
-# googleAnalytics       = "xxx"             # Tracking code, eg. "UA-111111111-1"
+baseurl                  = "https://example.org/"               # Your domain name. Must end with "/"
+languageCode             = "en-us"
+title                    = "Call me Sam"
+theme                    = "sam"
+pygmentsStyle            = "monokai"                     # https://help.farbox.com/pygments.html
+pygmentsCodefences       = true
+# googleAnalytics        = "xxx"             # Tracking code, eg. "UA-111111111-1"
 
 [params]
-    dateform            = "Mon Jan 02, 2006"
-    dateformfull        = "Mon Jan 2 2006 15:04:05 EST"
-    favicon             = "/sam.ico"
-    homepage            = "main"                        # What to call the home page link
-    galleryFolder       = "images/"                     # Where you've put your images, after "/content/gallery/"
-    clickablePhotos     = true                          # Allow links to the full size images
-    footerText          = "Call me Sam, a theme for Hugo."
+    dateform             = "Mon Jan 02, 2006"
+    dateformfull         = "Mon Jan 2 2006 15:04:05 EST"
+    favicon              = "/sam.ico"
+    homepage             = "main"                        # What to call the home page link
+    galleryFolder        = "images/"                     # Where you've put your images, after "/content/gallery/"
+    clickablePhotos      = true                          # Allow links to the full size images
+    smallPreviewImages   = true                          # Show small images from the subfolder instead of the big versions in the gallery
+                                                         # Note: This will only become active if clickablePhotos is also true.
+    smallImagesSubfolder = "small/"                      # The subfolder for the small versions of the images under the gallery (with trailing slash)
+                                                         # For each image the small version has to have the same filename as the big version.
+    footerText           = "Call me Sam, a theme for Hugo."
 
 # Metadata
-    description         = "A new Hugo site."            # Max 160 characters show in search results
-    twitterCard         = "summary_large_image"         # Card value “summary”, “summary_large_image”, “app”, or “player”
-    primaryImage        = "/tn.png"                     # Image that shows on Twitter cards and OpenGraph links
+    description          = "A new Hugo site."            # Max 160 characters show in search results
+    twitterCard          = "summary_large_image"         # Card value “summary”, “summary_large_image”, “app”, or “player”
+    primaryImage         = "/tn.png"                     # Image that shows on Twitter cards and OpenGraph links
 
 [[params.mainMenu]]
     link = "/posts"

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -13,7 +13,7 @@ pygmentsCodefences       = true
     homepage             = "main"                        # What to call the home page link
     galleryFolder        = "images/"                     # Where you've put your images, after "/content/gallery/"
     clickablePhotos      = true                          # Allow links to the full size images
-    smallPreviewImages   = true                          # Show small images from the subfolder instead of the big versions in the gallery
+    smallPreviewImages   = false                         # Show small images from the subfolder instead of the big versions in the gallery
                                                          # Note: This will only become active if clickablePhotos is also true.
     smallImagesSubfolder = "small/"                      # The subfolder for the small versions of the images under the gallery (with trailing slash)
                                                          # For each image the small version has to have the same filename as the big version.

--- a/layouts/gallery/list.html
+++ b/layouts/gallery/list.html
@@ -8,9 +8,14 @@
 {{ $folder := (print $content $path $name) }}
 
 {{ $files := readDir $folder }}
+ 
+{{ $previewSubdirectory := .Site.Params.smallImagesSubfolder | default "small/"}}
+{{ $previewImagesEnabled := .Site.Params.smallPreviewImages }}
 
 {{ range shuffle $files }}
-<div><a href="{{ $src | absURL }}{{ .Name }}"><img src="{{ $src | absURL }}{{ .Name }}" alt="{{ .Name }}"/></a></div>
+
+{{ if not .IsDir }}<div><a href="{{ $src | absURL }}{{ .Name }}">{{ if $previewImagesEnabled}}<img src="{{ $src | absURL }}{{ $previewSubdirectory }}{{ .Name }}" alt="{{ .Name }}"/>{{ else }}<img src="{{ $src | absURL }}{{ .Name }}" alt="{{ .Name }}"/>{{ end }}</a></div>{{ end }}
+
 {{ end }}</div>
 {{ else }}<div class="grid">
 {{ $name := .Site.Params.galleryFolder | default "images/"}}
@@ -23,5 +28,8 @@
 {{ $files := readDir $folder }}
 
 {{ range shuffle $files }}
-<div><img src="{{ $src | absURL }}{{ .Name }}" alt="{{ .Name }}"/></div>{{ end }}</div>{{ end }}
+
+{{ if not .IsDir }}<div><img src="{{ $src | absURL }}{{ .Name }}" alt="{{ .Name }}"/></div>{{ end }}
+
+{{ end }}</div>{{ end }}
 {{ if .Site.Params.mainMenu }}<div class="section bottom-menu">{{ partial "bottom_menu.html" (dict "Page" . "show_back_menu_item" false) }}</div>{{ end }}<div class="section footer">{{ partial "footer.html" . }}</div></div></body>

--- a/pug/gallery/list.pug
+++ b/pug/gallery/list.pug
@@ -16,12 +16,21 @@ body
             | {{ $folder := (print $content $path $name) }}
             |
             | {{ $files := readDir $folder }}
+            | 
+            | {{ $previewSubdirectory := .Site.Params.smallImagesSubfolder | default "small/"}}
+            | {{ $previewImagesEnabled := .Site.Params.smallPreviewImages }}
             |
             | {{ range shuffle $files }}
             |
+            | {{ if not .IsDir }}
             div
                 a(href='{{ $src | absURL }}{{ .Name }}')
+                    | {{ if $previewImagesEnabled}}
+                    img(src='{{ $src | absURL }}{{ $previewSubdirectory }}{{ .Name }}' alt='{{ .Name }}')
+                    | {{ else }}
                     img(src='{{ $src | absURL }}{{ .Name }}' alt='{{ .Name }}')
+                    | {{ end }}
+            | {{ end }}
             |
             | {{ end }}
         |
@@ -39,8 +48,11 @@ body
             |
             | {{ range shuffle $files }}
             |
+            | {{ if not .IsDir }}
             div
                 img(src='{{ $src | absURL }}{{ .Name }}' alt='{{ .Name }}')
+            | {{ end }}
+            |
             | {{ end }}
         | {{ end }}
         | {{ if .Site.Params.mainMenu }}


### PR DESCRIPTION
On my setup the gallery page was getting really big in filesize as I added more and more images to the gallery. To solve this problem I added an option to show small versions of the images that are kept in a subfolder of the images folder in the gallery and only link to the big versions.

Thanks for this awesome theme, stay awesome! 🙂 