### PR TITLE
Use base templates and blocks

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html><html><head>
+{{ block "head" . }}
+{{ partial "head.html" . }}
+{{ end }}
+
+{{ block "head_resources" . }}
+<!-- Use this block to link to further resources like .js or .css files. -->
+{{ end }}
+<title>
+{{ block "title" . }}
+{{ .Title }}
+{{ end }}
+</title></head><body>
+{{ block "main" . }}<div class="wrap">
+{{ block "section_title" . }}<div class="section" id="title">{{ .Title }}</div>{{ end }}
+
+{{ block "section_content" . }}<div class="section" id="content">{{ .Content }}</div>{{ end }}
+
+{{ block "bottom-menu" . }}
+{{ if .Site.Params.mainMenu }}<div class="section bottom-menu">{{ partial "bottom_menu.html" (dict "Page" . "show_back_menu_item" false) }}</div>{{ end }}
+{{ end }}
+
+{{ block "footer" . }}<div class="section footer">{{ partial "footer.html" . }}</div>{{ end }}
+</div>{{ end }}
+</body></html>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,6 +1,6 @@
-{{ partial "head.html" . }}<body><div class="wrap"><div class="section" id="content"><h1>{{ .Title }}</h1>{{ .Content }}<ul>{{ range .Data.Pages }}<li>
+{{ define "section_content" }}<div class="section" id="content">{{ .Content }}<ul>{{ range .Data.Pages }}<li>
 {{ if .Params.showDate }}
 
 {{ .Date.Format (.Site.Params.dateForm | default "Mon Jan 02, 2006")}} --
 
-{{ end }}<a href="{{.Permalink}}">{{.Title}}</a></li>{{ end }}</ul></div>{{ if .Site.Params.mainMenu }}<div class="section bottom-menu">{{ partial "bottom_menu.html" (dict "Page" . "show_back_menu_item" false) }}</div>{{ end }}<div class="section footer">{{ partial "footer.html" . }}</div></div></body>
+{{ end }}<a href="{{.Permalink}}">{{.Title}}</a></li>{{ end }}</ul></div>{{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,1 +1,3 @@
-{{ partial "head.html" . }}<body><div class="wrap"><div class="section" id="title">{{ .Title }}</div><div class="section" id="content">{{ .Content }}</div>{{ if .Site.Params.mainMenu }}<div class="section bottom-menu">{{ partial "bottom_menu.html" (dict "Page" . "show_back_menu_item" false) }}</div>{{ end }}<div class="section footer">{{ partial "footer.html" . }}</div></div></body>
+{{ define "no-difference-to-baseof-here" }}
+<!-- These three lines are a workaround. They are needed to inherit from baseof without changing anything. -->
+{{ end }}

--- a/layouts/gallery/list.html
+++ b/layouts/gallery/list.html
@@ -1,4 +1,4 @@
-{{ partial "head.html" . }}<body><div class="wrap"><div class="section" id="content">{{ .Content }}</div>
+{{ define "section_content" }}<div class="section" id="content">{{ .Content }}</div>
 {{ if .Site.Params.clickablePhotos }}<div class="grid">
 {{ $name := .Site.Params.galleryFolder | default "images/"}}
 {{ $path := "gallery/" }}
@@ -32,4 +32,4 @@
 {{ if not .IsDir }}<div><img src="{{ $src | absURL }}{{ .Name }}" alt="{{ .Name }}"/></div>{{ end }}
 
 {{ end }}</div>{{ end }}
-{{ if .Site.Params.mainMenu }}<div class="section bottom-menu">{{ partial "bottom_menu.html" (dict "Page" . "show_back_menu_item" false) }}</div>{{ end }}<div class="section footer">{{ partial "footer.html" . }}</div></div></body>
+{{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,5 +1,5 @@
-{{ partial "head.html" . }}<body><div class="section" id="splash">{{ if .Site.Params.mainMenu }}
+<!DOCTYPE html><html><head>{{ partial "head.html" . }}<title>{{ .Title }}</title></head><body><div class="section" id="splash">{{ if .Site.Params.mainMenu }}
 {{ range .Site.Params.mainMenu }}<div class="big-link"><a href="{{.link}}">{{.text}}</a></div>{{ end }}
 {{ else }}
 {{ range .Site.Sections }}<div class="big-link"> <a href="{{.Permalink}}">{{.Title}}</a></div>{{ end }}
-{{ end }}</div></body>
+{{ end }}</div></body></html>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,7 +1,3 @@
-<!DOCTYPE html>
-<html lang="en-US">
-
-<head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="chrome=1">
     <meta name="HandheldFriendly" content="True">
@@ -20,8 +16,7 @@
     <meta name="og:type" content="website">
     <meta name="og:url" content="{{.Site.BaseURL}}">
     <meta name="og:image" itemprop="image primaryImageOfPage" content="{{.Site.Params.primaryImage | default "tn.png" | absURL}}">
-    <!-- Characters max 60-->
-    <title>{{.Title}}</title>
+
     <link rel="shortcut icon" href="{{.Site.Params.favicon | default "sam.ico" | absURL }}" id="favicon">
     <link rel="stylesheet" href="{{ "css/style.css" | absURL}}">
     <!-- Google fonts-->
@@ -40,7 +35,3 @@
         gtag('config', '{{.Site.GoogleAnalytics}}');
     </script>
     {{ end }}
-
-</head>
-
-</html>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,37 +1,37 @@
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="chrome=1">
-    <meta name="HandheldFriendly" content="True">
-    <meta name="MobileOptimized" content="320">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="referrer" content="no-referrer">
-    <!-- Character max 160-->
-    <meta name="description" content="{{.Site.Params.description | default "Call me Sam, a theme for Hugo."}}">
-    <!-- Card value “summary”, “summary_large_image”, “app”, or “player”-->
-    <meta name="twitter:card" content="summary">
-    <meta name="twitter:domain" content="{{.Site.BaseURL}}">
-    <!-- Min 120x120px-->
-    <meta name="twitter:image" content="{{ .Site.Params.primaryImage | default "tn.png" | absURL }}">
-    <meta name="twitter:title" property="og:title" itemprop="title name" content="{{.Site.Title | default "Sam"}}">
-    <meta name="twitter:description" property="og:description" itemprop="description" content="{{.Site.Params.description | default "Call me Sam, a theme for Hugo."}}">
-    <meta name="og:type" content="website">
-    <meta name="og:url" content="{{.Site.BaseURL}}">
-    <meta name="og:image" itemprop="image primaryImageOfPage" content="{{.Site.Params.primaryImage | default "tn.png" | absURL}}">
+<meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="chrome=1">
+<meta name="HandheldFriendly" content="True">
+<meta name="MobileOptimized" content="320">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="referrer" content="no-referrer">
+<!-- Character max 160-->
+<meta name="description" content="{{.Site.Params.description | default "Call me Sam, a theme for Hugo."}}">
+<!-- Card value “summary”, “summary_large_image”, “app”, or “player”-->
+<meta name="twitter:card" content="summary">
+<meta name="twitter:domain" content="{{.Site.BaseURL}}">
+<!-- Min 120x120px-->
+<meta name="twitter:image" content="{{ .Site.Params.primaryImage | default "tn.png" | absURL }}">
+<meta name="twitter:title" property="og:title" itemprop="title name" content="{{.Site.Title | default "Sam"}}">
+<meta name="twitter:description" property="og:description" itemprop="description" content="{{.Site.Params.description | default "Call me Sam, a theme for Hugo."}}">
+<meta name="og:type" content="website">
+<meta name="og:url" content="{{.Site.BaseURL}}">
+<meta name="og:image" itemprop="image primaryImageOfPage" content="{{.Site.Params.primaryImage | default "tn.png" | absURL}}">
 
-    <link rel="shortcut icon" href="{{.Site.Params.favicon | default "sam.ico" | absURL }}" id="favicon">
-    <link rel="stylesheet" href="{{ "css/style.css" | absURL}}">
-    <!-- Google fonts-->
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Didact+Gothic">
-    <!-- jQuery-->
-    <script src="https://code.jquery.com/jquery-3.2.1.min.js" integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4="
-        crossorigin="anonymous"></script>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    {{ if .Site.GoogleAnalytics }}
-    <script async src="https://www.googletagmanager.com/gtag/js?id={{.Site.GoogleAnalytics}}"></script>
-    <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag() { dataLayer.push(arguments); }
-        gtag('js', new Date());
+<link rel="shortcut icon" href="{{.Site.Params.favicon | default "sam.ico" | absURL }}" id="favicon">
+<link rel="stylesheet" href="{{ "css/style.css" | absURL}}">
+<!-- Google fonts-->
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Didact+Gothic">
+<!-- jQuery-->
+<script src="https://code.jquery.com/jquery-3.2.1.min.js" integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4="
+    crossorigin="anonymous"></script>
+<!-- Global site tag (gtag.js) - Google Analytics -->
+{{ if .Site.GoogleAnalytics }}
+<script async src="https://www.googletagmanager.com/gtag/js?id={{.Site.GoogleAnalytics}}"></script>
+<script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
 
-        gtag('config', '{{.Site.GoogleAnalytics}}');
-    </script>
-    {{ end }}
+    gtag('config', '{{.Site.GoogleAnalytics}}');
+</script>
+{{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -22,7 +22,7 @@
 <!-- Google fonts-->
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Didact+Gothic">
 <!-- jQuery-->
-<script src="https://code.jquery.com/jquery-3.2.1.min.js" integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4="
+<script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
     crossorigin="anonymous"></script>
 <!-- Global site tag (gtag.js) - Google Analytics -->
 {{ if .Site.GoogleAnalytics }}

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -1,3 +1,5 @@
-{{ partial "head.html" . }}<body><div class="wrap"><div class="section" id="title">{{ .Title }}</div><div class="section" id="content">{{ .Date.Format (.Site.Params.dateForm | default "Mon Jan 02, 2006") }} &#183; {{ .WordCount }} words
+{{ define "section_content" }}<div class="section" id="content">{{ .Date.Format (.Site.Params.dateForm | default "Mon Jan 02, 2006") }} &#183; {{ .WordCount }} words
 
-{{ with .Params.tags }}<div class="tag-container">{{ range . }}<span class="tag"><a href="{{ "tags/" | absURL }}{{ . | urlize }}">{{.}}</a></span>{{ end }}</div>{{ end }}<hr/>{{ .Content }}</div><div class="section bottom-menu">{{ partial "bottom_menu.html" (dict "Page" . "show_back_menu_item" true) }}</div><div class="section footer">{{ partial "footer.html" . }}</div></div></body>
+{{ with .Params.tags }}<div class="tag-container">{{ range . }}<span class="tag"><a href="{{ "tags/" | absURL }}{{ . | urlize }}">{{.}}</a></span>{{ end }}</div>{{ end }}<hr/>{{ .Content }}</div>{{ end }}
+
+{{ define "bottom-menu" }}<div class="section bottom-menu">{{ partial "bottom_menu.html" (dict "Page" . "show_back_menu_item" true) }}</div>{{ end }}

--- a/pug/_default/baseof.pug
+++ b/pug/_default/baseof.pug
@@ -1,0 +1,47 @@
+doctype html
+html
+    head
+        |
+        | {{ block "head" . }}
+        | {{ partial "head.html" . }}
+        | {{ end }}
+        |
+        | {{ block "head_resources" . }}
+        | <!-- Use this block to link to further resources like .js or .css files. -->
+        | {{ end }}
+        |
+        title
+            |
+            | {{ block "title" . }}
+            | {{ .Title }}
+            | {{ end }}
+            |
+    body
+        |
+        | {{ block "main" . }}
+        .wrap
+            |
+            | {{ block "section_title" . }}
+            .section#title
+                | {{ .Title }}
+            | {{ end }}
+            |
+            | {{ block "section_content" . }}
+            .section#content
+                | {{ .Content }}
+            | {{ end }}
+            |
+            | {{ block "bottom-menu" . }}
+            | {{ if .Site.Params.mainMenu }}
+            .section.bottom-menu
+                | {{ partial "bottom_menu.html" (dict "Page" . "show_back_menu_item" false) }}
+            | {{ end }}
+            | {{ end }}
+            |
+            | {{ block "footer" . }}
+            .section.footer
+                | {{ partial "footer.html" . }}
+            | {{ end }}
+            |
+        | {{ end }}
+        |

--- a/pug/_default/list.pug
+++ b/pug/_default/list.pug
@@ -1,24 +1,15 @@
-| {{ partial "head.html" . }}
-
-body
-    .wrap
-        .section#content
-            h1 {{ .Title }}
-            | {{ .Content }}
-            ul
-                | {{ range .Data.Pages }}
-                li
-                    |
-                    | {{ if .Params.showDate }}
-                    |
-                    | {{ .Date.Format (.Site.Params.dateForm | default "Mon Jan 02, 2006")}} --
-                    |
-                    | {{ end }}
-                    a(href='{{.Permalink}}') {{.Title}}
-                | {{ end }}
-        | {{ if .Site.Params.mainMenu }}
-        .section.bottom-menu
-            | {{ partial "bottom_menu.html" (dict "Page" . "show_back_menu_item" false) }}
+| {{ define "section_content" }}
+.section#content
+    | {{ .Content }}
+    ul
+        | {{ range .Data.Pages }}
+        li
+            |
+            | {{ if .Params.showDate }}
+            |
+            | {{ .Date.Format (.Site.Params.dateForm | default "Mon Jan 02, 2006")}} --
+            |
+            | {{ end }}
+            a(href='{{.Permalink}}') {{.Title}}
         | {{ end }}
-        .section.footer
-            | {{ partial "footer.html" . }}
+| {{ end }}

--- a/pug/_default/single.pug
+++ b/pug/_default/single.pug
@@ -1,14 +1,3 @@
-| {{ partial "head.html" . }}
-
-body
-    .wrap
-        .section#title
-            | {{ .Title }}
-        .section#content
-            | {{ .Content }}
-        | {{ if .Site.Params.mainMenu }}
-        .section.bottom-menu
-              | {{ partial "bottom_menu.html" (dict "Page" . "show_back_menu_item" false) }}
-        | {{ end }}
-        .section.footer
-            | {{ partial "footer.html" . }}
+| {{ define "no-difference-to-baseof-here" }}
+| <!-- These three lines are a workaround. They are needed to inherit from baseof without changing anything. -->
+| {{ end }}

--- a/pug/gallery/list.pug
+++ b/pug/gallery/list.pug
@@ -1,63 +1,55 @@
-| {{ partial "head.html" . }}
-
-body
-    .wrap
-        .section#content
-            | {{ .Content }}
-        |
-        | {{ if .Site.Params.clickablePhotos }}
-        .grid
-            |
-            | {{ $name := .Site.Params.galleryFolder | default "images/"}}
-            | {{ $path := "gallery/" }}
-            | {{ $content := "/content/" }}
-            | {{ $src := (print $path $name) }}
-            |
-            | {{ $folder := (print $content $path $name) }}
-            |
-            | {{ $files := readDir $folder }}
-            | 
-            | {{ $previewSubdirectory := .Site.Params.smallImagesSubfolder | default "small/"}}
-            | {{ $previewImagesEnabled := .Site.Params.smallPreviewImages }}
-            |
-            | {{ range shuffle $files }}
-            |
-            | {{ if not .IsDir }}
-            div
-                a(href='{{ $src | absURL }}{{ .Name }}')
-                    | {{ if $previewImagesEnabled}}
-                    img(src='{{ $src | absURL }}{{ $previewSubdirectory }}{{ .Name }}' alt='{{ .Name }}')
-                    | {{ else }}
-                    img(src='{{ $src | absURL }}{{ .Name }}' alt='{{ .Name }}')
-                    | {{ end }}
+| {{ define "section_content" }}
+.section#content
+    | {{ .Content }}
+|
+| {{ if .Site.Params.clickablePhotos }}
+.grid
+    |
+    | {{ $name := .Site.Params.galleryFolder | default "images/"}}
+    | {{ $path := "gallery/" }}
+    | {{ $content := "/content/" }}
+    | {{ $src := (print $path $name) }}
+    |
+    | {{ $folder := (print $content $path $name) }}
+    |
+    | {{ $files := readDir $folder }}
+    | 
+    | {{ $previewSubdirectory := .Site.Params.smallImagesSubfolder | default "small/"}}
+    | {{ $previewImagesEnabled := .Site.Params.smallPreviewImages }}
+    |
+    | {{ range shuffle $files }}
+    |
+    | {{ if not .IsDir }}
+    div
+        a(href='{{ $src | absURL }}{{ .Name }}')
+            | {{ if $previewImagesEnabled}}
+            img(src='{{ $src | absURL }}{{ $previewSubdirectory }}{{ .Name }}' alt='{{ .Name }}')
+            | {{ else }}
+            img(src='{{ $src | absURL }}{{ .Name }}' alt='{{ .Name }}')
             | {{ end }}
-            |
-            | {{ end }}
-        |
-        | {{ else }}
-        .grid
-            |
-            | {{ $name := .Site.Params.galleryFolder | default "images/"}}
-            | {{ $path := "gallery/" }}
-            | {{ $content := "/content/" }}
-            | {{ $src := (print $path $name) }}
-            |
-            | {{ $folder := (print $content $path $name) }}
-            |
-            | {{ $files := readDir $folder }}
-            |
-            | {{ range shuffle $files }}
-            |
-            | {{ if not .IsDir }}
-            div
-                img(src='{{ $src | absURL }}{{ .Name }}' alt='{{ .Name }}')
-            | {{ end }}
-            |
-            | {{ end }}
-        | {{ end }}
-        | {{ if .Site.Params.mainMenu }}
-        .section.bottom-menu
-            | {{ partial "bottom_menu.html" (dict "Page" . "show_back_menu_item" false) }}
-        | {{ end }}
-        .section.footer
-            | {{ partial "footer.html" . }}
+    | {{ end }}
+    |
+    | {{ end }}
+|
+| {{ else }}
+.grid
+    |
+    | {{ $name := .Site.Params.galleryFolder | default "images/"}}
+    | {{ $path := "gallery/" }}
+    | {{ $content := "/content/" }}
+    | {{ $src := (print $path $name) }}
+    |
+    | {{ $folder := (print $content $path $name) }}
+    |
+    | {{ $files := readDir $folder }}
+    |
+    | {{ range shuffle $files }}
+    |
+    | {{ if not .IsDir }}
+    div
+        img(src='{{ $src | absURL }}{{ .Name }}' alt='{{ .Name }}')
+    | {{ end }}
+    |
+    | {{ end }}
+| {{ end }}
+| {{ end }}

--- a/pug/index.pug
+++ b/pug/index.pug
@@ -1,15 +1,20 @@
-| {{ partial "head.html" . }}
-
-body
-    .section#splash
-        | {{ if .Site.Params.mainMenu }}
-        | {{ range .Site.Params.mainMenu }}
-        .big-link
-            a(href='{{.link}}') {{.text}}
-        | {{ end }}
-        | {{ else }}
-        | {{ range .Site.Sections }}
-        .big-link 
-            a(href='{{.Permalink}}') {{.Title}}
-        | {{ end }}
-        | {{ end }}
+doctype html
+html
+  |
+  head
+      | {{ partial "head.html" . }}
+      title
+        | {{ .Title }}
+  body
+      .section#splash
+          | {{ if .Site.Params.mainMenu }}
+          | {{ range .Site.Params.mainMenu }}
+          .big-link
+              a(href='{{.link}}') {{.text}}
+          | {{ end }}
+          | {{ else }}
+          | {{ range .Site.Sections }}
+          .big-link 
+              a(href='{{.Permalink}}') {{.Title}}
+          | {{ end }}
+          | {{ end }}

--- a/pug/posts/single.pug
+++ b/pug/posts/single.pug
@@ -1,22 +1,19 @@
-| {{ partial "head.html" . }}
-
-body
-    .wrap
-        .section#title
-            | {{ .Title }}
-        .section#content
-            | {{ .Date.Format (.Site.Params.dateForm | default "Mon Jan 02, 2006") }} &#183; {{ .WordCount }} words
-            |
-            | {{ with .Params.tags }}
-            div.tag-container
-                | {{ range . }}
-                span.tag
-                    a(href!='{{ "tags/" | absURL }}{{ . | urlize }}') {{.}}
-                | {{ end }}
-            | {{ end }}
-            hr
-            | {{ .Content }}
-        .section.bottom-menu
-              | {{ partial "bottom_menu.html" (dict "Page" . "show_back_menu_item" true) }}
-        .section.footer
-            | {{ partial "footer.html" . }}
+| {{ define "section_content" }}
+.section#content
+    | {{ .Date.Format (.Site.Params.dateForm | default "Mon Jan 02, 2006") }} &#183; {{ .WordCount }} words
+    |
+    | {{ with .Params.tags }}
+    div.tag-container
+        | {{ range . }}
+        span.tag
+            a(href!='{{ "tags/" | absURL }}{{ . | urlize }}') {{.}}
+        | {{ end }}
+    | {{ end }}
+    hr
+    | {{ .Content }}
+| {{ end }}
+|
+| {{ define "bottom-menu" }}
+.section.bottom-menu
+        | {{ partial "bottom_menu.html" (dict "Page" . "show_back_menu_item" true) }}
+| {{ end }}


### PR DESCRIPTION
I took a closer look at the generated HTML files when using this theme. I recognized that all files are not well-formed HTML  because the `</html>` end tag comes before the body tag (and the whole content of the webpage). The problem is that the head.html contains both the start and the end html tag. Every web page includes that file at the beginning and by that, has the end html tag before the actual content.

This PR solves this problem by using [hugos base template](https://gohugo.io/templates/base/) feature . The __default/baseof.{html,pug}_ contains the general structure of all pages (except _index.{html, pug}_) and marks special areas with the `block ` function . All other templates only change those of these marked blocks of the base template they need to adapt by using the `define ` function. 
This reduces duplicate code and makes it easier to customize the theme and add new layouts.